### PR TITLE
Fix import in example_test.go

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,7 @@ package hub_test
 import (
 	"fmt"
 
-	"github.com/cenkalti/hub"
+	"github.com/cenk/hub"
 )
 
 // Different event kinds


### PR DESCRIPTION
The example was using the previous URL for import.